### PR TITLE
Backwards compatibility for indices

### DIFF
--- a/bin/rcrestore
+++ b/bin/rcrestore
@@ -57,10 +57,19 @@ echo "[*] Restoring data..."
 data_dir=$(tail -n 1 /var/snap/rocketchat-server/common/restore/extraction.log)
 data_dir=$(dirname ${data_dir})
 log_name="mongorestore.log"
-mongorestore --db parties --drop ${data_dir} &> "${restore_dir}/${log_name}"
+mongorestore --db parties --noIndexRestore --drop ${data_dir} &> "${restore_dir}/${log_name}"
 if [[ $? != 0 ]]
 then
     abort "Failed to execute mongorestore from ${data_dir}!"
+    exit
+fi
+
+echo "[*] Preparing database..."
+log_name="mongoprepare.log"
+mongo parties --eval "db.repairDatabase()" --verbose &> "${restore_dir}/${log_name}"
+if [[ $? != 0 ]]
+then
+    abort "Failed to prepare database for usage!"
     exit
 fi
 


### PR DESCRIPTION
Added --noIndexRestore so previous backups with different index versions may be restored
Added a repairDatabase call to rebuild indices and compress the database, which hopefully won't take long for large DBs and will make them run smoother
This should only be run on a master/primary DB, which is the case within the snap