### PR TITLE
[IMPROVEMENT] remove the mongodb connection attempt loop from the startup script

### DIFF
--- a/resources/mongo.sh
+++ b/resources/mongo.sh
@@ -3,7 +3,7 @@
 start() {
 	LC_ALL=C mongod --bind_ip 127.0.0.1 --port 27017 \
 		--pidfilepath $SNAP_COMMON/mongod.pid \
-		--logpath=$SNAP_COMMON/mongod.log --logRotate=reopen --logAppend=true \
+		--logpath=$SNAP_COMMON/mongod.log --logRotate=reopen --logappend \
 		--dbpath=$SNAP_COMMON \
 		--smallfiles --journal --replSet rs0 \
 		--fork

--- a/resources/mongo.sh
+++ b/resources/mongo.sh
@@ -1,0 +1,28 @@
+#! /bin/sh
+
+start() {
+	LC_ALL=C mongod --bind_ip 127.0.0.1 --port 27017 \
+		--pidfilepath $SNAP_COMMON/mongod.pid \
+		--logpath=$SNAP_COMMON/mongod.log \
+		--dbpath=$SNAP_COMMON \
+		--smallfiles --journal --replSet rs0 \
+		--fork
+}
+
+stop() {
+	LC_ALL=C mongod --dbpath=$SNAP_COMMON --shutdown
+}
+
+logs() {
+	tail -f $SNAP_COMMON/mongod.log
+}
+
+shell() {
+	LC_ALL=C mongo
+}
+
+if [ -z "$1" ]; then
+	shell
+else
+	eval "${1#--}"
+fi

--- a/resources/mongo.sh
+++ b/resources/mongo.sh
@@ -3,7 +3,7 @@
 start() {
 	LC_ALL=C mongod --bind_ip 127.0.0.1 --port 27017 \
 		--pidfilepath $SNAP_COMMON/mongod.pid \
-		--logpath=$SNAP_COMMON/mongod.log \
+		--logpath=$SNAP_COMMON/mongod.log --logRotate=reopen --logAppend=true \
 		--dbpath=$SNAP_COMMON \
 		--smallfiles --journal --replSet rs0 \
 		--fork

--- a/resources/mongo.sh
+++ b/resources/mongo.sh
@@ -3,7 +3,7 @@
 start() {
 	LC_ALL=C mongod --bind_ip 127.0.0.1 --port 27017 \
 		--pidfilepath $SNAP_COMMON/mongod.pid \
-		--logpath=$SNAP_COMMON/mongod.log --logRotate=reopen --logappend \
+		--logpath=$SNAP_COMMON/mongod.log \
 		--dbpath=$SNAP_COMMON \
 		--smallfiles --journal --replSet rs0 \
 		--fork

--- a/resources/startRocketChat
+++ b/resources/startRocketChat
@@ -43,9 +43,6 @@ function start_rocketchat {
 	node $SNAP/main.js
 }
 
-sleep_time=5
-try_times=0
-
 function try_start {
 
         refreshing="$(snapctl get snap-refreshing)"
@@ -53,23 +50,7 @@ function try_start {
             exit 0
         fi
 
-	search=$(ps --pid $(cat $SNAP_COMMON/mongod.pid) -o comm=)
-
-	if [ $search ]
-        	then
-                	start_rocketchat
-        	else
-			if [[ "$try_times" == 5 || "$try_times" > 5 ]]; then
-		                echo "Was unable to connect to Mongo.  Please make sure Mongo has started successfully: sudo systemctl status snap.rocketchat-server.rocketchat-mongo to view logs: sudo journalctl -u snap.rocketchat-server.rocketchat-mongo"
-               			exit 1;
-        		fi
-
-			((try_times += 1))
-			((sleep_time += 5))
-                	echo "Mongo is not available, can't start. Waiting ${sleep_time} seconds and trying again"
-			sleep $sleep_time
-			try_start
-	fi
+        start_rocketchat
 }
 
 try_start

--- a/resources/startmongo
+++ b/resources/startmongo
@@ -1,1 +1,0 @@
-env LC_ALL=C mongod --bind_ip 127.0.0.1 --pidfilepath $SNAP_COMMON/mongod.pid --smallfiles --journal --dbpath=$SNAP_COMMON --replSet rs0

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,7 @@
 # 5.  `snapcraft snap`
 
 name: rocketchat-server
-version: ROCKET_CHAT_BUILD_VERSION
+version: 3.17.0
 summary: Rocket.Chat server
 description: Have your own Slack like online chat, built with Meteor. https://rocket.chat/
 confinement: strict
@@ -17,17 +17,27 @@ apps:
     rocketchat-server:
         command: startRocketChat
         daemon: simple
+        after: [rocketchat-mongo-daemon]
         plugs: [network, network-bind, removable-media]
+    rocketchat-mongo-daemon:
+        command: mongo.sh --start
+        stop-command: mongo.sh --stop
+        daemon: forking
+        plugs:
+            - network
+            - network-bind
+            - network-observer
     rocketchat-mongo:
-        command: startmongo
+        command: mongo.sh --logs
+        stop-command: mongo.sh --stop
+        after: [rocketchat-mongo-daemon]
         daemon: simple
-        plugs: [network, network-bind, network-observe]
     rocketchat-caddy:
         command: env LC_ALL=C caddy -conf=$SNAP_DATA/Caddyfile
         daemon: simple
         plugs: [network, network-bind]
     mongo:
-        command: env LC_ALL=C mongo
+        command: mongo.sh
         plugs: [network]
     restoredb:
         command: env LC_ALL=C restoredb
@@ -95,7 +105,7 @@ parts:
         organize:
             backupdb: bin/backupdb
             restoredb: bin/restoredb
-            startmongo: bin/startmongo
+            mongo.sh: bin/mongo.sh
             startRocketChat: bin/startRocketChat
             initreplset.js: bin/initreplset.js
             Caddyfile: bin/Caddyfile

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,7 @@
 # 5.  `snapcraft snap`
 
 name: rocketchat-server
-version: 3.17.0
+version: ROCKET_CHAT_BUILD_VERSION
 summary: Rocket.Chat server
 description: Have your own Slack like online chat, built with Meteor. https://rocket.chat/
 confinement: strict


### PR DESCRIPTION
## How this works

1. If started as a daemon, the parent mongodb process waits for the child
to be ready to accept connections before exiting. 

2. The `rocketchat-mongo` app now takes care of the logs.

3. The `after` keys make sure both `rocketchat-server` and `rocketchat-mongo` starts only after `rocketchat-mongo-daemon`'s startup is complete.

4. Since the service type (or daemon type) for `rocketchat-mongo-daemon` is "forking", units that depend on this, are not going to start until the parent process of this app exits.