### PR TITLE
Fix: Add mount-observe and system-observe plug to snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,6 +23,8 @@ apps:
       - network
       - network-bind
       - network-observe
+      - mount-observe
+      - system-observe
 
   rocketchat-server:
     command: bin/start_rocketchat.sh


### PR DESCRIPTION
# Proposed changes
Add the plugs `mount-observe` and `system-observe` to rocketchat-mongo. Should stop AppArmor from spamming the log when mongo tries to access `@{PROC}/@{pid}/mountinfo` or `@{PROC}/vmstat`.

# Issue(s)
fixes RocketChat/Rocket.Chat#14562
partly fixes #62