### PR TITLE
ci: don't calculate greater than as it is all consuming and can fail for lack of context

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -60,15 +60,15 @@ jobs:
 
           current_version="$(yq -e .version snap/snapcraft.yaml)" # no release candidate
 
-          is_gt() {
+          is_lt() {
             local v1=(${1//./ })
             local v2=(${2//./ })
-            (( ${v1[0]} > ${v2[0]} )) && return 0
-            (( ${v1[1]} > ${v2[1]} )) && return 0
-            (( ${v1[2]} > ${v2[2]} )) && return 0
+            (( ${v1[0]} < ${v2[0]} )) && return 0
+            (( ${v1[1]} < ${v2[1]} )) && return 0
+            (( ${v1[2]} < ${v2[2]} )) && return 0
             return 1
           }
-          if is_gt $version $current_version; then
+          if ! is_lt $version $current_version; then
             run=true
             if [[ $candidate == 'false' ]]; then commit=true; fi
           fi

--- a/.github/workflows/force_release.yaml
+++ b/.github/workflows/force_release.yaml
@@ -11,9 +11,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.ref_name }}
+          path: server-snap
             
       - name: Set variables
         id: prepare
+        working-directory: server-snap
         shell: bash
         run: |
           track="${{ github.ref_name }}"
@@ -30,21 +32,25 @@ jobs:
       - name: 'Build the Snap package'
         uses: snapcore/action-build@v1
         id: snap-build
+        with:
+          path: server-snap
           
       - name: 'Clone tests repository'
         uses: actions/checkout@v3
         with:
           repository: debdutdeb/rocket.chat.tests
           submodules: true
+          path: tests
 
       - name: 'Run tests'
         shell: bash
         env:
           ROCKETCHAT_TAG: ${{ steps.prepare.outputs.current-version }}
-          ROCKETCHAT_SNAP: ${{ steps.snap-build.outputs.snap }}
         run: |
           sudo apt-get --no-install-recommends install jo jq -y
-          bash ./run_snap.bash
+          export ROCKETCHAT_SNAP=$(realpath ${{ steps.snap-build.outputs.snap }})
+          cd tests &&
+            bash ./run_snap.bash
 
       - name: 'Upload to snapstore'
         uses: snapcore/action-publish@v1
@@ -58,7 +64,7 @@ jobs:
         if: always()
         uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
         with:
-          job_name: '*Snap ${{ steps.prepare.outputs.current-version }} tests*'
+          job_name: '*Snap ${{ steps.prepare.outputs.current-version }} publish*'
           url: ${{ secrets.ROCKETCHAT_WEBHOOK }}
           type: ${{ job.status }}
           mention: 'debdut.chakraborty'


### PR DESCRIPTION
If there are two version strings, and we perform a greater than, in this
way, since every next step doesn't know about the last one, it can
result in a false positive.

Instead, if we test if A is less than B, for the three steps, if the
previous did not cause a return, means we are still ok. Therefore this
current step is all we need.
