### PR TITLE
ci: sync with 6.x branch

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -60,15 +60,15 @@ jobs:
 
           current_version="$(yq -e .version snap/snapcraft.yaml)" # no release candidate
 
-          is_gt() {
+          is_lt() {
             local v1=(${1//./ })
             local v2=(${2//./ })
-            (( ${v1[0]} > ${v2[0]} )) && return 0
-            (( ${v1[1]} > ${v2[1]} )) && return 0
-            (( ${v1[2]} > ${v2[2]} )) && return 0
+            (( ${v1[0]} < ${v2[0]} )) && return 0
+            (( ${v1[1]} < ${v2[1]} )) && return 0
+            (( ${v1[2]} < ${v2[2]} )) && return 0
             return 1
           }
-          if is_gt $version $current_version; then
+          if ! is_lt $version $current_version; then
             run=true
             if [[ $candidate == 'false' ]]; then commit=true; fi
           fi

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -40,22 +40,23 @@ jobs:
           version=${{ inputs.tag }}
           snap_track="${version:0:1}.x"
           echo "snap-track: $snap_track"
-
-          grep -q "rc" <<< "$version" && candidate=true || candidate=false
-          echo "candidate: $candidate"
-
-          echo "candidate=$candidate" >> $GITHUB_OUTPUT
           echo "snap-track=$snap_track" >> $GITHUB_OUTPUT
 
+          candidate=false
           run=false
           commit=false
 
-          current_version="$(yq -e .version snap/snapcraft.yaml)"
-          if [[ $current_version != $version ]]; then
-            run=true
+          if [[ $version =~ ^([0-9]+\.[0-9]+\.[0-9]+)-rc\.[0-9]+$ ]]; then
+            # if version is release candidate, we need to strip out the "rc.+" part to know if we actually should push/run or not
+            # we never expect a release candidate and stable release of the same major.minor to be in race
+            candidate=true
+            version=${BASH_REMATCH[1]}
+            echo "version: $version"
           fi
-          echo "run: $run"
-          echo "run=$run" >> $GITHUB_OUTPUT
+          echo "candidate: $candidate"
+          echo "candidate=$candidate" >> $GITHUB_OUTPUT
+
+          current_version="$(yq -e .version snap/snapcraft.yaml)" # no release candidate
 
           is_gt() {
             local v1=(${1//./ })
@@ -65,10 +66,13 @@ jobs:
             (( ${v1[2]} > ${v2[2]} )) && return 0
             return 1
           }
-          if [[ $candidate == 'false' ]] &&  is_gt $version $current_version; then # if candidate, don't commit
-            commit=true
+          if is_gt $version $current_version; then
+            run=true
+            if [[ $candidate == 'false' ]]; then commit=true; fi
           fi
+          echo "run: $run"
           echo "commit: $commit"
+          echo "run=$run" >> $GITHUB_OUTPUT
           echo "commit=$commit" >>$GITHUB_OUTPUT
 
   build:

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -11,6 +11,8 @@ on:
         required: true
       github-token:
         required: true
+      rocketchat-webhook:
+        required: true
 
 # TODO need to make this workflow work according to snap standard of release making.
 # But for that, we also need a releases endpoint and primary release process update.
@@ -111,6 +113,15 @@ jobs:
           echo "filename: $file_name"
           echo "filename=$file_name" >>$GITHUB_OUTPUT
 
+      - name: Notify core team
+        uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
+        with:
+          job_name: '*Snap build status*'
+          url: ${{ secrets.rocketchat-webhook }}
+          type: ${{ job.status }}
+          mention: 'debdut.chakraborty'
+          mention_if: failure
+
   can-i-run:
     needs:
       - prepare
@@ -138,6 +149,15 @@ jobs:
         run: |
           sudo apt-get --no-install-recommends install jo jq -y
           bash ./run_snap.bash
+
+      - name: Notify core team
+        uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
+        with:
+          job_name: '*Snap build tests status*'
+          url: ${{ secrets.rocketchat-webhook }}
+          type: ${{ job.status }}
+          mention: 'debdut.chakraborty'
+          mention_if: failure
 
   publish-snap:
     needs:
@@ -186,6 +206,15 @@ jobs:
           fail_on_unmatched_files: true
           target_commitish: ${{ needs.prepare.outputs.snap-track }}
           generate_release_notes: true
+
+      - name: Notify core team
+        uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
+        with:
+          job_name: '*Snap publish status*'
+          url: ${{ secrets.rocketchat-webhook }}
+          type: ${{ job.status }}
+          mention: 'debdut.chakraborty'
+          mention_if: failure
 
   repo-actions:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -114,6 +114,7 @@ jobs:
           echo "filename=$file_name" >>$GITHUB_OUTPUT
 
       - name: Notify core team
+        if: always()
         uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
         with:
           job_name: '*Snap build status*'
@@ -151,6 +152,7 @@ jobs:
           bash ./run_snap.bash
 
       - name: Notify core team
+        if: always()
         uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
         with:
           job_name: '*Snap build tests status*'
@@ -208,6 +210,7 @@ jobs:
           generate_release_notes: true
 
       - name: Notify core team
+        if: always()
         uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
         with:
           job_name: '*Snap publish status*'

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -117,7 +117,7 @@ jobs:
         if: always()
         uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
         with:
-          job_name: '*Snap build status*'
+          job_name: '*Snap ${{ inputs.tag }} build*'
           url: ${{ secrets.rocketchat-webhook }}
           type: ${{ job.status }}
           mention: 'debdut.chakraborty'
@@ -155,7 +155,7 @@ jobs:
         if: always()
         uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
         with:
-          job_name: '*Snap build tests status*'
+          job_name: '*Snap ${{ inputs.tag }} tests*'
           url: ${{ secrets.rocketchat-webhook }}
           type: ${{ job.status }}
           mention: 'debdut.chakraborty'
@@ -213,7 +213,7 @@ jobs:
         if: always()
         uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
         with:
-          job_name: '*Snap publish status*'
+          job_name: '*Snap ${{ inputs.tag }} publish*'
           url: ${{ secrets.rocketchat-webhook }}
           type: ${{ job.status }}
           mention: 'debdut.chakraborty'

--- a/.github/workflows/force_release.yaml
+++ b/.github/workflows/force_release.yaml
@@ -11,9 +11,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.ref_name }}
+          path: server-snap
             
       - name: Set variables
         id: prepare
+        working-directory: server-snap
         shell: bash
         run: |
           track="${{ github.ref_name }}"
@@ -30,21 +32,25 @@ jobs:
       - name: 'Build the Snap package'
         uses: snapcore/action-build@v1
         id: snap-build
+        with:
+          path: server-snap
           
       - name: 'Clone tests repository'
         uses: actions/checkout@v3
         with:
           repository: debdutdeb/rocket.chat.tests
           submodules: true
+          path: tests
 
       - name: 'Run tests'
         shell: bash
         env:
           ROCKETCHAT_TAG: ${{ steps.prepare.outputs.current-version }}
-          ROCKETCHAT_SNAP: ${{ steps.snap-build.outputs.snap }}
         run: |
           sudo apt-get --no-install-recommends install jo jq -y
-          bash ./run_snap.bash
+          export ROCKETCHAT_SNAP=$(realpath ${{ steps.snap-build.outputs.snap }})
+          cd tests &&
+            bash ./run_snap.bash
 
       - name: 'Upload to snapstore'
         uses: snapcore/action-publish@v1
@@ -58,7 +64,7 @@ jobs:
         if: always()
         uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
         with:
-          job_name: '*Snap ${{ steps.prepare.outputs.current-version }} tests*'
+          job_name: '*Snap ${{ steps.prepare.outputs.current-version }} publish*'
           url: ${{ secrets.ROCKETCHAT_WEBHOOK }}
           type: ${{ job.status }}
           mention: 'debdut.chakraborty'

--- a/.github/workflows/force_release.yaml
+++ b/.github/workflows/force_release.yaml
@@ -11,10 +11,40 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.ref_name }}
+            
+      - name: Set variables
+        id: prepare
+        shell: bash
+        run: |
+          track="${{ github.ref_name }}"
+          current_version=$(yq -e .version snap/snapcraft.yaml)
+          channels="${track}/edge,${track}/stable"
+          if [[ $current_version =~ rc ]]; then
+            channels+=",${track}/candidate"
+          fi
+          echo "channels: $channels"
+          echo "current_version: $current_version"
+          echo "channels=$channels" >>$GITHUB_OUTPUT
+          echo "current-version=$current_version" >>$GITHUB_OUTPUT
 
       - name: 'Build the Snap package'
         uses: snapcore/action-build@v1
         id: snap-build
+          
+      - name: 'Clone tests repository'
+        uses: actions/checkout@v3
+        with:
+          repository: debdutdeb/rocket.chat.tests
+          submodules: true
+
+      - name: 'Run tests'
+        shell: bash
+        env:
+          ROCKETCHAT_TAG: ${{ steps.prepare.outputs.current-version }}
+          ROCKETCHAT_SNAP: ${{ steps.snap-build.outputs.snap }}
+        run: |
+          sudo apt-get --no-install-recommends install jo jq -y
+          bash ./run_snap.bash
 
       - name: 'Upload to snapstore'
         uses: snapcore/action-publish@v1
@@ -22,22 +52,15 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:
           snap: ${{ steps.snap-build.outputs.snap }}
-          release: ${{ format('{0}/edge', github.ref_name) }}
+          release: ${{ steps.prepare.outputs.channels }}
 
-      - name: 'Promote to other risk levels'
-        shell: bash
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
-        run: |
-          track=${{ github.ref_name }}
-          version="$(awk "/version:/ { print \$2 }" snap/snapcraft.yaml)"
-          revision="$(snapcraft list-revisions rocketchat-server --arch amd64 | grep "$track/edge" | head -1 | cut -d' ' -f1)"
-          echo "revision: $revision"
-          echo "version: $version"
-          echo "track: $track"
-          if printf "$version" | grep -Eq 'rc$'; then
-            snapcraft release rocketchat-server "$revision" "$track/candidate"
-          else
-            snapcraft release rocketchat-server "$revision" "$track/stable"
-          fi
+      - name: 'Notify core team'
+        if: always()
+        uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
+        with:
+          job_name: '*Snap ${{ steps.prepare.outputs.current-version }} tests*'
+          url: ${{ secrets.ROCKETCHAT_WEBHOOK }}
+          type: ${{ job.status }}
+          mention: 'debdut.chakraborty'
+          mention_if: failure
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.2.0
+version: 6.2.8
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.3.3
+version: 6.3.4
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.1.5
+version: 6.1.6
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.3.8
+version: 6.4.0
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.3.4
+version: 6.3.5
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.3.7
+version: 6.3.8
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.3.2
+version: 6.3.3
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.3.11
+version: 6.4.6
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.2.12
+version: 6.3.1
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.4.7
+version: 6.4.8
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.3.0
+version: 6.2.12
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.1.6
+version: 6.2.0
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.3.5
+version: 6.3.6
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.5.0
+version: 6.5.1
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.3.10
+version: 6.4.1
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.3.1
+version: 6.3.2
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.4.2
+version: 6.4.3
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.2.9
+version: 6.2.10
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.2.11
+version: 6.3.0
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.5.2
+version: 6.4.9
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/
 
-epoch: 10*
+epoch: 10
 
 grade: stable
 confinement: strict

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.2.10
+version: 6.2.11
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/
 
-epoch: 10
+epoch: 10*
 
 grade: stable
 confinement: strict

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.4.3
+version: 6.4.4
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.3.6
+version: 6.3.7
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.4.5
+version: 6.3.11
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.2.8
+version: 6.2.9
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.4.1
+version: 6.4.2
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.3.9
+version: 6.3.10
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.4.4
+version: 6.4.5
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.4.6
+version: 6.3.12
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.3.12
+version: 6.4.7
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.4.8
+version: 6.5.0
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.5.1
+version: 6.5.2
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: rocketchat-server
 title: Rocket.Chat Server
 base: core20
-version: 6.4.0
+version: 6.3.9
 summary: An Open Source Slack Alternative
 description: |
   Have your own Slack like online chat, built with Meteor. https://rocket.chat/


### PR DESCRIPTION
- fix: new revision with bridge epoch
- fix: newest 6.x revision epoch revised
- Bump Rocket.Chat version to 6.1.6
- chore: bump version to 6.2.0
- fix: version comparison in candidate releases
- chore: add core team notifications
- fix: always run notification step
- chore: version context in notifications
- new: add tests to force release workflow
- Bump Rocket.Chat version to 6.2.8
- Bump Rocket.Chat version to 6.2.9
- Bump Rocket.Chat version to 6.2.10
- Bump Rocket.Chat version to 6.2.11
- Bump version to 6.3.0
- Bump Rocket.Chat version to 6.2.12
- Bump Rocket.Chat version to 6.3.1
- Bump Rocket.Chat version to 6.3.2
- Bump Rocket.Chat version to 6.3.3
- Bump Rocket.Chat version to 6.3.4
- Bump Rocket.Chat version to 6.3.5
- Bump Rocket.Chat version to 6.3.6
- Bump Rocket.Chat version to 6.3.7
- Bump Rocket.Chat version to 6.3.8
- Bump Rocket.Chat version to 6.4.0
- Bump Rocket.Chat version to 6.3.9
- Bump Rocket.Chat version to 6.3.10
- Bump Rocket.Chat version to 6.4.1
- Bump Rocket.Chat version to 6.4.2
- Bump Rocket.Chat version to 6.4.3
- Bump Rocket.Chat version to 6.4.4
- Bump Rocket.Chat version to 6.4.5
- Bump Rocket.Chat version to 6.3.11
- Bump Rocket.Chat version to 6.4.6
- Bump Rocket.Chat version to 6.3.12
- Bump Rocket.Chat version to 6.4.7
- Bump Rocket.Chat version to 6.4.8
- Bump Rocket.Chat version to 6.5.0
- Bump Rocket.Chat version to 6.5.1
- Bump Rocket.Chat version to 6.5.2
- Bump Rocket.Chat version to 6.4.9
- ci: don't calculate greater than as it is all consuming and can fail for lack of context (#67)
