### PR TITLE
Apply mount-observe and system-observe plug fix to 6.x release branch

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,6 +23,8 @@ apps:
       - network
       - network-bind
       - network-observe
+      - mount-observe
+      - system-observe
 
   rocketchat-server:
     command: bin/start_rocketchat.sh


### PR DESCRIPTION
I have used my patched snap (#61) for a while now and confirm that it fixes Apparmor's syslog spam if all snap plugs are connected:
```
root@snapshot-146178093-debian-8gb-hel1-1:~# snap connections rocketchat-server
Interface        Plug                               Slot              Notes
mount-observe    rocketchat-server:mount-observe    :mount-observe    manual
network          rocketchat-server:network          :network          -
network-bind     rocketchat-server:network-bind     :network-bind     -
network-observe  rocketchat-server:network-observe  :network-observe  manual
removable-media  rocketchat-server:removable-media  :removable-media  manual
system-observe   rocketchat-server:system-observe   :system-observe   manual
```
Imho this change is ready to be published on the 6.x snap track.

- actually closes #61 
- fixes RocketChat/Rocket.Chat#14562
- partly fixes #62 