### PR TITLE
fix(env): add fallback for SNAP_ARCH to fix missing LD_LIBRARY_PATH paths

### DIFF
--- a/helpers/environment.sh
+++ b/helpers/environment.sh
@@ -3,6 +3,11 @@
 declare -A ARCH=([amd64]="x86_64" [arm64]="aarch64")
 
 export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+
+if [[ -z "${SNAP_ARCH:-}" ]]; then
+    SNAP_ARCH=$(dpkg --print-architecture 2>/dev/null || echo "amd64")
+fi
+
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/${ARCH[$SNAP_ARCH]}-linux-gnu:$SNAP/usr/lib/${ARCH[$SNAP_ARCH]}-linux-gnu"
 export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH"
 export PYTHONPATH="$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.10/dist-packages:$SNAP/usr/lib/python3/site-packages:$SNAP/usr/lib/python3.10/site-packages:${PYTHONPATH:-}"


### PR DESCRIPTION
## Proposed changes
This fixes an issue where the pre-refresh hook fails because `SNAP_ARCH` is not set by snapd in the hook context, causing `environment.sh` to build a broken `LD_LIBRARY_PATH`. This prevents mongod from finding bundled shared libraries.

This PR adds a fallback for `SNAP_ARCH` utilizing `dpkg --print-architecture` if the environment variable is empty.

Closes RocketChat/Rocket.Chat#41001